### PR TITLE
Port library to ManimGL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,11 @@
-# Manim Voiceover
+# Manim Voiceover (ManimGL port)
 
-<p>
-    <a href="https://github.com/ManimCommunity/manim-voiceover/workflows/Build/badge.svg"><img src="https://github.com/ManimCommunity/manim-voiceover/workflows/Build/badge.svg" alt="Github Actions Status"></a>
-    <a href="https://pypi.org/project/manim_voiceover/"><img src="https://img.shields.io/pypi/v/manim_voiceover.svg?style=flat&logo=pypi" alt="PyPI Latest Release"></a>
-    <a href="https://pepy.tech/project/manim_voiceover"><img src="https://pepy.tech/badge/manim_voiceover/month?" alt="Downloads"> </a>
-    <a href="https://voiceover.manim.community/en/latest"><img src="https://readthedocs.org/projects/manim_voiceover/badge/?version=latest" alt="Documentation Status"></a>
-    <a href="https://github.com/ManimCommunity/manim-voiceover/blob/main/LICENSE"><img src="https://img.shields.io/github/license/ManimCommunity/manim-voiceover.svg?color=blue" alt="License"></a>
-    <a href="https://manim.community/discord"><img src="https://dcbadge.vercel.app/api/server/qY23bthHTY?style=flat" alt="Discord"></a>
-</p>
-
-Manim Voiceover is an extension for [ManimGL](https://github.com/3b1b/manim) for all things voiceover:
-
-- Add voiceovers to Manim videos *directly in Python* without having to use a video editor.
-- Record voiceovers with your microphone during rendering with a simple command line interface.
-- Develop animations with auto-generated AI voices from various free and proprietary services.
-- Per-word timing of animations, i.e. trigger animations at specific words in the voiceover, even for the recordings. This works thanks to [OpenAI Whisper](https://github.com/openai/whisper).
-
-Here is a demo:
-
-https://user-images.githubusercontent.com/2453968/198145393-6a1bd709-4441-4821-8541-45d5f5e25be7.mp4
-
-Currently supported TTS services (aside from the CLI that allows you to records your own voice):
-
-- [Azure Text to Speech](https://azure.microsoft.com/en-us/services/cognitive-services/text-to-speech/) (Recommended for AI voices)
-- [Coqui TTS](https://github.com/coqui-ai/TTS/)
-- [gTTS](https://github.com/pndurette/gTTS/)
-- [pyttsx3](https://github.com/nateshmbhat/pyttsx3)
-
-[Check out the documentation for more details.](https://voiceover.manim.community/)
+This repository is a port of the original [Manim Voiceover](https://github.com/ManimCommunity/manim-voiceover) package for use with [ManimGL](https://github.com/3b1b/manim).
 
 ## Installation
 
-[Installation instructions in Manim Voiceover docs.](https://voiceover.manim.community/en/latest/installation.html)
+Install directly from GitHub:
 
-## Get started
-
-[Check out the docs to get started with Manim Voiceover.](https://voiceover.manim.community/en/latest/quickstart.html)
-
-## Examples
-
-[Check out the example gallery to get inspired.](https://voiceover.manim.community/en/latest/examples.html)
-
-## Translate
-
-Manim Voiceover can use machine translation services like [DeepL](https://www.deepl.com/) to translate voiceovers into other languages. [Check out the docs for more details.](https://voiceover.manim.community/en/latest/translate.html)
+```bash
+pip install git+https://github.com/manim-voiceover/manim-voiceover.git
+```

--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ This repository is a port of the original [Manim Voiceover](https://github.com/M
 Install directly from GitHub:
 
 ```bash
-pip install git+https://github.com/manim-voiceover/manim-voiceover.git
+pip install git+https://github.com/azhuchkov/manim-voiceover.git
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <a href="https://manim.community/discord"><img src="https://dcbadge.vercel.app/api/server/qY23bthHTY?style=flat" alt="Discord"></a>
 </p>
 
-Manim Voiceover is a [Manim](https://manim.community) plugin for all things voiceover:
+Manim Voiceover is an extension for [ManimGL](https://github.com/3b1b/manim) for all things voiceover:
 
 - Add voiceovers to Manim videos *directly in Python* without having to use a video editor.
 - Record voiceovers with your microphone during rendering with a simple command line interface.

--- a/examples/approximating-tau.py
+++ b/examples/approximating-tau.py
@@ -3,7 +3,7 @@
 # Rendered version: https://www.youtube.com/watch?v=xmHzyafJEec
 # Taken from: https://github.com/NutronStar45/manim-videos/blob/main/2022/09/approx_tau.py
 
-from manim import *
+from manimlib import *
 from numpy import sqrt, sin, cos
 from manim_voiceover import VoiceoverScene
 from manim_voiceover.services.azure import AzureService

--- a/examples/azure-example.py
+++ b/examples/azure-example.py
@@ -1,4 +1,4 @@
-from manim import *
+from manimlib import *
 from manim_voiceover import VoiceoverScene
 from manim_voiceover.services.azure import AzureService
 

--- a/examples/bookmark-example.py
+++ b/examples/bookmark-example.py
@@ -1,4 +1,4 @@
-from manim import *
+from manimlib import *
 from manim_voiceover import VoiceoverScene
 
 # from manim_voiceover.services.coqui import CoquiService

--- a/examples/coqui-example.py
+++ b/examples/coqui-example.py
@@ -1,4 +1,4 @@
-from manim import *
+from manimlib import *
 from manim_voiceover import VoiceoverScene
 from manim_voiceover.services.coqui import CoquiService
 

--- a/examples/elevenlabs-example.py
+++ b/examples/elevenlabs-example.py
@@ -1,4 +1,4 @@
-from manim import *
+from manimlib import *
 
 from manim_voiceover import VoiceoverScene
 from manim_voiceover.services.elevenlabs import ElevenLabsService

--- a/examples/gtts-example.py
+++ b/examples/gtts-example.py
@@ -1,4 +1,4 @@
-from manim import *
+from manimlib import *
 from manim_voiceover import VoiceoverScene
 from manim_voiceover.services.gtts import GTTSService
 

--- a/examples/openai-example.py
+++ b/examples/openai-example.py
@@ -1,4 +1,4 @@
-from manim import *
+from manimlib import *
 from manim_voiceover import VoiceoverScene
 from manim_voiceover.services.openai import OpenAIService
 

--- a/examples/pyttsx3-example.py
+++ b/examples/pyttsx3-example.py
@@ -1,4 +1,4 @@
-from manim import *
+from manimlib import *
 from manim_voiceover import VoiceoverScene
 from manim_voiceover.services.pyttsx3 import PyTTSX3Service
 

--- a/examples/quadratic-formula-arabic.py
+++ b/examples/quadratic-formula-arabic.py
@@ -2,7 +2,7 @@
 # License: MIT (see LICENSE for details)
 # Rendered version: https://www.youtube.com/watch?v=Sflx0aoFrVg
 
-from manim import *
+from manimlib import *
 from pathlib import Path
 import os
 from numpy import left_shift
@@ -18,10 +18,11 @@ RESOLUTION = ""
 FLAGS = (
     f"-pqk -o ar_formule_quadratique_logo2 --disable_caching"  # "-pql --fps 10 -n 39 "
 )
-pixel_height = config["pixel_height"]  #  1080 is default
-pixel_width = config["pixel_width"]  # 1920 is default
-frame_width = config["frame_width"]
-frame_height = config["frame_height"]
+# ManimGL stores resolution inside the camera configuration
+pixel_width, pixel_height = config["camera"]["resolution"]
+# Scene geometry parameters are defined under "sizes"
+frame_height = config["sizes"]["frame_height"]
+frame_width = frame_height * pixel_width / pixel_height
 
 dims = {
     "h": (1920, 1080)
@@ -29,7 +30,7 @@ dims = {
 }
 # ------ إضافة/إزالة Mobject للـمشهد
 
-# config["background_color"] = None#"#0f1653"
+# config["camera"]["background_color"] = None#"#0f1653"
 # config["max_files_cached"] = 200
 # تحديد مكان الشيء في المشهد
 SCENE = "test1"  #  ضع اسم المشهد هنا
@@ -40,7 +41,7 @@ if __name__ == "__main__":
     os.system(f"manim {script_name} {SCENE} {FLAGS}")
 
 
-config.background_color = "#e0e6e2"  # None #
+config["camera"]["background_color"] = "#e0e6e2"  # None #
 Tex.set_default(color=BLACK)
 Text.set_default(color=BLACK)
 Mobject.set_default(color=RED)
@@ -48,7 +49,7 @@ Dot.set_default(color=BLACK)
 VMobject.set_default(color=BLACK, stroke_width=4)
 Square.set_default(color=GREEN)
 
-main_tex = config.tex_template
+main_tex = config["tex"]["template"]
 
 r_preamble = r"""
 \usepackage[T2A]{fontenc}
@@ -131,7 +132,7 @@ class QuadraticFormulaArabic(VoiceoverScene):
         # print(len(title))
         fs = 75
         arfs = 120
-        config.tex_template = main_tex
+        config["tex"]["template"] = main_tex
         # You can specify which tex file to use
         # for example Tex("balbalbla", tex_template = my_template)
         # eq5

--- a/examples/recorder-example.py
+++ b/examples/recorder-example.py
@@ -1,4 +1,4 @@
-from manim import *
+from manimlib import *
 from manim_voiceover import VoiceoverScene
 from manim_voiceover.services.recorder import RecorderService
 

--- a/examples/translation-example/translation-example.py
+++ b/examples/translation-example/translation-example.py
@@ -1,5 +1,5 @@
 import os
-from manim import *
+from manimlib import *
 from manim_voiceover import VoiceoverScene
 from manim_voiceover.services.gtts import GTTSService
 from manim_voiceover.translate import get_gettext

--- a/examples/voiceover-demo.py
+++ b/examples/voiceover-demo.py
@@ -1,4 +1,4 @@
-from manim import *
+from manimlib import *
 import pygments.styles as code_styles
 from manim_voiceover import VoiceoverScene
 

--- a/manim_voiceover/__init__.py
+++ b/manim_voiceover/__init__.py
@@ -3,4 +3,7 @@ from manim_voiceover.voiceover_scene import VoiceoverScene
 
 import pkg_resources
 
-__version__: str = pkg_resources.get_distribution(__name__).version
+try:
+    __version__: str = pkg_resources.get_distribution(__name__).version
+except pkg_resources.DistributionNotFound:
+    __version__ = "0.0.0"

--- a/manim_voiceover/helper.py
+++ b/manim_voiceover/helper.py
@@ -8,7 +8,7 @@ import pip
 import textwrap
 from pydub import AudioSegment
 from pathlib import Path
-from manim import logger
+from manimlib import logger
 
 
 def chunks(lst: list, n: int):

--- a/manim_voiceover/services/azure.py
+++ b/manim_voiceover/services/azure.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 from dotenv import find_dotenv, load_dotenv
-from manim import logger
+from manimlib import logger
 
 from manim_voiceover.helper import (
     create_dotenv_file,

--- a/manim_voiceover/services/base.py
+++ b/manim_voiceover/services/base.py
@@ -5,7 +5,8 @@ import json
 import sys
 import hashlib
 from pathlib import Path
-from manim import config, logger
+from manimlib.config import manim_config as config
+from manimlib import logger
 from slugify import slugify
 from manim_voiceover.defaults import (
     DEFAULT_VOICEOVER_CACHE_DIR,
@@ -72,7 +73,9 @@ class SpeechService(ABC):
         if cache_dir is not None:
             self.cache_dir = cache_dir
         else:
-            self.cache_dir = Path(config.media_dir) / DEFAULT_VOICEOVER_CACHE_DIR
+            self.cache_dir = (
+                Path(config["directories"]["sounds"]) / DEFAULT_VOICEOVER_CACHE_DIR
+            )
 
         if not os.path.exists(self.cache_dir):
             os.makedirs(self.cache_dir)

--- a/manim_voiceover/services/coqui.py
+++ b/manim_voiceover/services/coqui.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from manim import logger
+from manimlib import logger
 from manim_voiceover.helper import prompt_ask_missing_package, remove_bookmarks, wav2mp3
 from manim_voiceover.services.base import SpeechService
 

--- a/manim_voiceover/services/elevenlabs.py
+++ b/manim_voiceover/services/elevenlabs.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 from dotenv import find_dotenv, load_dotenv
-from manim import logger
+from manimlib import logger
 
 from manim_voiceover.helper import create_dotenv_file, remove_bookmarks
 from manim_voiceover.services.base import SpeechService

--- a/manim_voiceover/services/gtts.py
+++ b/manim_voiceover/services/gtts.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from manim import logger
+from manimlib import logger
 from manim_voiceover.helper import prompt_ask_missing_extras, remove_bookmarks
 
 try:

--- a/manim_voiceover/services/openai.py
+++ b/manim_voiceover/services/openai.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 from dotenv import find_dotenv, load_dotenv
-from manim import logger
+from manimlib import logger
 
 from manim_voiceover.helper import (
     create_dotenv_file,

--- a/manim_voiceover/services/pyttsx3.py
+++ b/manim_voiceover/services/pyttsx3.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from manim import logger
+from manimlib import logger
 from manim_voiceover.helper import prompt_ask_missing_extras
 
 try:

--- a/manim_voiceover/services/recorder/__init__.py
+++ b/manim_voiceover/services/recorder/__init__.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from manim_voiceover.helper import msg_box, prompt_ask_missing_extras, remove_bookmarks
 
 from manim_voiceover.services.base import SpeechService
-from manim import logger
+from manimlib import logger
 
 try:
     import pyaudio

--- a/manim_voiceover/services/recorder/utility.py
+++ b/manim_voiceover/services/recorder/utility.py
@@ -5,7 +5,7 @@ import sys
 import sched
 from pathlib import Path
 from pydub import AudioSegment
-from manim import logger
+from manimlib import logger
 
 from manim_voiceover.helper import trim_silence, wav2mp3
 

--- a/manim_voiceover/tracker.py
+++ b/manim_voiceover/tracker.py
@@ -47,10 +47,8 @@ class VoiceoverTracker:
         self.data = data
         self.cache_dir = cache_dir
         self.duration = get_duration(Path(cache_dir) / self.data["final_audio"])
-        # last_t = scene.last_t
-        last_t = scene.renderer.time
-        if last_t is None:
-            last_t = 0
+        # Use the scene's internal time to anchor the audio timestamps
+        last_t = scene.time or 0
         self.start_t = last_t
         self.end_t = last_t + self.duration
 
@@ -130,7 +128,7 @@ class VoiceoverTracker:
             int: The remaining duration of the voiceover in seconds.
         """
         # result= max(self.end_t - self.scene.last_t, 0)
-        result = max(self.end_t - self.scene.renderer.time + buff, 0)
+        result = max(self.end_t - self.scene.time + buff, 0)
         # print(result)
         return result
 
@@ -161,7 +159,7 @@ class VoiceoverTracker:
         self._check_bookmarks()
         if not mark in self.bookmark_times:
             raise Exception("There is no <bookmark mark='%s' />" % mark)
-        result = max(self.bookmark_times[mark] - self.scene.renderer.time + buff, 0)
+        result = max(self.bookmark_times[mark] - self.scene.time + buff, 0)
         if limit is not None:
             result = min(limit, result)
         return result

--- a/manim_voiceover/tracker.py
+++ b/manim_voiceover/tracker.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 import re
 import numpy as np
-from manim import logger
+from manimlib import logger
 
 from typing import Optional, List
 from scipy.interpolate import interp1d
 
-from manim import Scene
+from manimlib.scene.scene import Scene
 from manim_voiceover.modify_audio import get_duration
 from manim_voiceover.helper import remove_bookmarks
 

--- a/manim_voiceover/translate/gettext_utils.py
+++ b/manim_voiceover/translate/gettext_utils.py
@@ -4,7 +4,7 @@ import typing as t
 
 import subprocess
 
-from manim import logger
+from manimlib import logger
 
 from manim_voiceover.helper import prompt_ask_missing_extras
 

--- a/manim_voiceover/translate/render.py
+++ b/manim_voiceover/translate/render.py
@@ -117,13 +117,12 @@ def main():
         os.environ["LOCALE"] = locale
         ofile = scene + "_" + locale + ".mp4"
         cmd = [
-            "manim",
+            "manimgl",
             f"-q{quality}",
             file,
             scene,
             "-o",
             ofile,
-            "--disable_caching",
         ]
 
         # Run manim with the command

--- a/manim_voiceover/voiceover_scene.py
+++ b/manim_voiceover/voiceover_scene.py
@@ -5,6 +5,8 @@ from typing import Optional, Generator
 import re
 import typing as t
 
+from dataclasses import dataclass
+
 from manimlib.scene.scene import Scene
 from manimlib.config import manim_config as config
 from manim_voiceover.services.base import SpeechService
@@ -22,6 +24,7 @@ class VoiceoverScene(Scene):
     current_tracker: Optional[VoiceoverTracker]
     create_subcaption: bool
     create_script: bool
+    subcaptions: list
 
     def set_speech_service(
         self,
@@ -38,10 +41,17 @@ class VoiceoverScene(Scene):
         """
         self.speech_service = speech_service
         self.current_tracker = None
+        self.subcaptions = []
         if config["file_writer"]["save_last_frame"]:
             self.create_subcaption = False
         else:
             self.create_subcaption = create_subcaption
+
+    @dataclass
+    class _Subtitle:
+        content: str
+        start: float
+        end: float
 
     def add_voiceover_text(
         self,
@@ -131,6 +141,36 @@ class VoiceoverScene(Scene):
                 offset=current_offset,
             )
             current_offset += chunk_duration
+
+    def add_subcaption(
+        self, content: str, duration: float = 1, offset: float = 0
+    ) -> None:
+        """Store a subcaption to be written at teardown."""
+        start = self.time + offset
+        end = start + duration
+        self.subcaptions.append(self._Subtitle(content, start, end))
+
+    @staticmethod
+    def _format_srt_timestamp(seconds: float) -> str:
+        ms = int(seconds * 1000)
+        s, ms = divmod(ms, 1000)
+        m, s = divmod(s, 60)
+        h, m = divmod(m, 60)
+        return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+    def tear_down(self) -> None:
+        if self.create_subcaption and self.subcaptions:
+            lines = []
+            for i, sc in enumerate(self.subcaptions, start=1):
+                start = self._format_srt_timestamp(sc.start)
+                end = self._format_srt_timestamp(sc.end)
+                lines.append(f"{i}\n{start} --> {end}\n{sc.content}\n")
+            srt_path = (
+                self.file_writer.get_output_file_rootname().with_suffix(".srt")
+            )
+            with open(srt_path, "w", encoding="utf-8") as f:
+                f.write("\n".join(lines))
+        super().tear_down()
 
     def add_voiceover_ssml(self, ssml: str, **kwargs) -> None:
         raise NotImplementedError("SSML input not implemented yet.")

--- a/manim_voiceover/voiceover_scene.py
+++ b/manim_voiceover/voiceover_scene.py
@@ -5,7 +5,8 @@ from typing import Optional, Generator
 import re
 import typing as t
 
-from manim import Scene, config
+from manimlib.scene.scene import Scene
+from manimlib.config import manim_config as config
 from manim_voiceover.services.base import SpeechService
 from manim_voiceover.tracker import VoiceoverTracker
 from manim_voiceover.helper import chunks, remove_bookmarks
@@ -37,7 +38,7 @@ class VoiceoverScene(Scene):
         """
         self.speech_service = speech_service
         self.current_tracker = None
-        if config.save_last_frame:
+        if config["file_writer"]["save_last_frame"]:
             self.create_subcaption = False
         else:
             self.create_subcaption = create_subcaption
@@ -155,7 +156,7 @@ class VoiceoverScene(Scene):
         Args:
             duration (float): The duration to wait for in seconds.
         """
-        if duration > 1 / config["frame_rate"]:
+        if duration > 1 / config["camera"]["fps"]:
             self.wait(duration)
 
     def wait_until_bookmark(self, mark: str) -> None:

--- a/manim_voiceover/voiceover_scene.py
+++ b/manim_voiceover/voiceover_scene.py
@@ -69,7 +69,8 @@ class VoiceoverScene(Scene):
 
         dict_ = self.speech_service._wrap_generate_from_text(text, **kwargs)
         tracker = VoiceoverTracker(self, dict_, self.speech_service.cache_dir)
-        self.renderer.skip_animations = self.renderer._original_skipping_status
+        # Restore the scene's animation skipping state before playing audio
+        self.skip_animations = self.original_skipping_status
         self.add_sound(str(Path(self.speech_service.cache_dir) / dict_["final_audio"]))
         self.current_tracker = tracker
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ manim_render_translation = 'manim_voiceover.translate.render:main'
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4"
-manim = "*"
+manimgl = "*"
 sox = "^1.4.1"
 python-dotenv = "^0.21.0"
 mutagen = "^1.46.0"
@@ -113,9 +113,6 @@ psutil = { version = "^5.8.0", python = "<3.10" }
 sphinxcontrib-video = "^0.0.1.dev3"
 sphinx-sitemap = "^2.2.1"
 
-
-[tool.poetry.plugins."manim.plugins"]
-"manim_voiceover" = "manim_voiceover"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary
- switch dependency and imports to ManimGL
- update voiceover scene and services for ManimGL config
- adjust translation renderer to call `manimgl`
- replace CE-specific config usage in Arabic example with ManimGL equivalents

## Testing
- `PYGLET_HEADLESS=1 pytest` *(fails: ModuleNotFoundError: No module named 'manim_voiceover')*

------
https://chatgpt.com/codex/tasks/task_e_689cdc8b2808832ab412e1f9d2c9b058